### PR TITLE
fix: 2025 exit date

### DIFF
--- a/web/api/internal.json
+++ b/web/api/internal.json
@@ -264,7 +264,7 @@
       "code": "DMU",
       "enter_date": "2022-09-09T00:00:00.000",
       "rough_enter_date": "Q3 2022",
-      "exit_date": "2025-07-29T00:00:00.000",
+      "exit_date": "2025-07-25T00:00:00.000",
       "rough_exit_date": "Q3 2025"
     },
     {
@@ -274,7 +274,7 @@
       "code": "BRO",
       "enter_date": "2022-11-18T00:00:00.000",
       "rough_enter_date": "Q4 2022",
-      "exit_date": "2025-07-29T00:00:00.000",
+      "exit_date": "2025-07-25T00:00:00.000",
       "rough_exit_date": "Q3 2025"
     },
     {
@@ -284,7 +284,7 @@
       "code": "ONE",
       "enter_date": "2023-02-03T00:00:00.000",
       "rough_enter_date": "Q1 2023",
-      "exit_date": "2025-07-29T00:00:00.000",
+      "exit_date": "2025-07-25T00:00:00.000",
       "rough_exit_date": "Q3 2025"
     },
     {
@@ -294,7 +294,7 @@
       "code": "MOM",
       "enter_date": "2023-04-14T00:00:00.000",
       "rough_enter_date": "Q2 2023",
-      "exit_date": "2025-07-29T00:00:00.000",
+      "exit_date": "2025-07-25T00:00:00.000",
       "rough_exit_date": "Q3 2025"
     },
     {
@@ -304,7 +304,7 @@
       "code": "MAT",
       "enter_date": "2023-05-12T00:00:00.000",
       "rough_enter_date": "Q2 2023",
-      "exit_date": "2025-07-29T00:00:00.000",
+      "exit_date": "2025-07-25T00:00:00.000",
       "rough_exit_date": "Q3 2025"
     },
     {


### PR DESCRIPTION
Partially revert 03f0ac4b0df588987b1a13a00d5354ad316fac65

As per https://magic.wizards.com/en/formats/standard:

> Once per year, after the fall set Prerelease, the four oldest sets in Standard rotate out.

EoE prerelease time frame as per https://magic.wizards.com/en/news/feature/where-and-how-to-play-edge-of-eternities
> Edge of Eternities Prerelease Events
> (July 25–31)

As per https://magic.wizards.com/en/news/announcements/aligning-the-universes-making-all-our-sets-legal-in-all-our-formats:
> Standard rotation in 2025 will occur with the release of Edge of Eternities.

And the Renewal article is only talking about MTG Arena and never mentions paper. 

Conclusion: doesn't that mean that 1st August is the paper release date, i.e. first day after the prerelease?

For reference: #311